### PR TITLE
Allow comma in hypersetup.pdfauthor

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -74,7 +74,7 @@ $endif$
 \usepackage[xetex, bookmarks, colorlinks, breaklinks]{hyperref}
 \hypersetup
 {
-  pdfauthor=$author$,
+  pdfauthor={$author$},
   pdfsubject=Invoice Nr. $invoice-nr$,
   pdftitle=Invoice Nr. $invoice-nr$,
   linkcolor=blue,


### PR DESCRIPTION
Some companies or authors might have a comma in the string, this is interpreted by hypersetup as a new key in its own data structure

Without this proposed fix, you will get:

! Package kvsetkeys Error: Undefined key `text after comma'.


btw thanks for this great stuff you did!