### PR TITLE
Add localization controls to YAML template

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,34 @@ Although I didn't test it, you can probably use this on Windows, too. Both [Pand
 
 ## Available settings
 
+- **`date`**: set a specific
 - **`VAT`**: Your VAT rate.
 - **`currency`**: Your currency code (USD, EUR...)
-- **`commasep`**: Set to `true` to use a comma as decimal separator. This is for display purposes only—remember to always use a dot to set the prices in your YAML file.
-- **`lang`**: Sets the main language through the `polyglossia` package. This is important for proper hyphenation and date format.
+- **`language`**: Sets the main language through the `polyglossia` package. This is important for proper hyphenation and date format.
 - **`seriffont`**: Used for the heading and the sender address. Hoefler Text is the default, but every font installed on your system should work out of the box (thanks, XeTeX!)
 - **`sansfont`**: Used to render the recipient address, the table and the closing note. Defaults to Helvetica Neue.
 - **`fontsize`**: Possible values here are 10pt, 11pt and 12pt.
 - **`geometry`**: A string that sets the margins through `geometry`. Read [this](https://www.sharelatex.com/learn/Page_size_and_margins) to learn how this package works.
 - **`closingnote`**: This gets printed after the table as a closing note. Use it to provide your bank details and a thank you message.
 - **`letterhead`**: include custom letterhead in the PDF (see below).
+- **`locale`**: configure strings and other locale related options. All strings default to their english variant
+  - **`commasep`**: Set to `true` to use a comma as decimal separator. This is for display purposes only—remember to always use a dot to set the prices in your YAML file.
+  - **`VAT`**: Set your local word for VAT here, e.g. MwSt. in geman
+  - **`price`**: Your local phrase for "price  in"
+  - **`description`**:  you get the idea ain't you? ;)
+  - **`subtotal`**: Netto
+  - **`total`**: Brutto
+  - **`itemPos`**: You can use `\phantom` to make shure the string is not displayed and not substituted by the english default value
 
 ## Custom letterhead
 
 If you have already designed your own letterhead and want to use it with this template, including it should be easy enough. Set the `letterhead` option to `true` to activate the `wallpaper` package in the template. `wallpaper` will look for a file named `letterhead.pdf` in the project root folder and print it on the PDF before compiling the document. Change the fonts to match the ones in your letterhead, adjust the margins with `geometry` and you should be all set.
+
+
+
+
+
+
 
 ## Recommended readings
 

--- a/details.yml
+++ b/details.yml
@@ -2,6 +2,7 @@
 invoice-nr: 2015-11-04
 author: Max Mustermann
 city: Musterstadt
+date: \today # set custom date here
 from:
 - Musterstraße 37
 - 12345 Musterstadt
@@ -24,22 +25,34 @@ service:
 - description: The last service provided
   price: 65.00
 
-closingnote: |
+closingnote: | # use \total to refer to the calculated sum
   Please transfer the due amount to the following bank account within the next 14 days:
-   
-    Mustermann GmbH  
-    Kreditinstitut: Deutsche Postbank AG  
-    IBAN: DE18 3601 0043 9999 9999 99  
-    BIC: PBNKDEFF  
+
+    Mustermann GmbH
+    Kreditinstitut: Deutsche Postbank AG
+    IBAN: DE18 3601 0043 9999 9999 99
+    BIC: PBNKDEFF
 
     We really appreciate your business and look forward to future projects together.
 
     Best regards,
 
+signature:
+# put path to an image of your signature here
+
 # Invoice settings
 currency: EUR
-# commasep: true
-lang: english
+
+# Locale settings
+language: english
+locale:
+  commasep: true
+  VAT: MwSt.
+  price: Preis in
+  description: Beschreibung
+  itemPos: Nr.
+  subtotal: Netto
+  total: Brutto
 
 # Typography and layout
 seriffont: Hoefler Text

--- a/template.tex
+++ b/template.tex
@@ -61,12 +61,32 @@ $endif$
 \setlist[itemize]{leftmargin=0.5cm} % Reduce list left indent
 \setlength{\tabcolsep}{9pt} % Larger gutter between columns
 
+% MACROS
+\newcommand{\total}{\STtag{totalsum}}
+% MACROS:Locale
+$if(locale.commasep)$\STsetdecimalsep{,}$endif$ % Use comma as decimal separator
+\newcommand{\localInvoice}
+{$if(locale.invoice)$$locale.invoice$$else$Invoice$endif$}
+\newcommand{\localDescription}
+{$if(locale.description)$$locale.description$$else$Description$endif$}
+\newcommand{\localItemPos}
+{$if(locale.itemPos)$$locale.itemPos$$else$Pos.$endif$}
+\newcommand{\localPriceIn}
+{$if(locale.price)$$locale.price$$else$Price in$endif$}
+\newcommand{\localSubtotal}
+{$if(locale.subtotal)$$locale.subtotal$$else$Subtotal$endif$}
+\newcommand{\localTotal}
+{$if(locale.total)$$locale.total$$else$Total$endif$}
+\newcommand{\localVAT}
+{$if(locale.VAT)$$locale.VAT$$else$VAT$endif$}
+
 
 % LANGUAGE
 %--------------------------------
-$if(lang)$
 \usepackage{polyglossia}
-\setmainlanguage{$lang$}
+$if(language)$
+\usepackage[$language$]{isodate}
+\setmainlanguage{$language$}
 $endif$
 
 % PDF SETUP
@@ -109,33 +129,31 @@ $endfor$
 
 \begin{flushright}
   \small
-  $city$, \today
+  $city$, $if(date)$$date$$else$\numdate\today$endif$
 \end{flushright}
 
 \vspace{1em}
 
 
-\section*{\textsc{Invoice} \textsc{\#$invoice-nr$}}
+\section*{\textsc{\localInvoice} \textsc{$invoice-nr$}}
 \footnotesize
 \newcounter{pos}
 \setcounter{pos}{0}
 \STautoround*{2} % Get spreadtab to always display the decimal part
-$if(commasep)$\STsetdecimalsep{,}$endif$ % Use comma as decimal separator
-
 \begin{spreadtab}{{tabular}[t t t]{lp{8.2cm}r}}
   \hdashline[1pt/1pt]
-  @ \noalign{\vskip 2mm} \textbf{Pos.} & @ \textbf{Description} & @ \textbf{Prices in $currency$} \\ \hline
-      $for(service)$ @ \noalign{\vskip 2mm} \refstepcounter{pos} \thepos 
-        & @ $service.description$ 
-        $if(service.details)$\newline \begin{itemize} 
-          $for(service.details)$\scriptsize \item $service.details$ 
+  @ \noalign{\vskip 2mm} \textbf{\localItemPos} & @ \textbf{\localDescription} & @ \textbf{\localPriceIn~$currency$} \\ \hline
+      $for(service)$ @ \noalign{\vskip 2mm} \refstepcounter{pos} \thepos
+        & @ $service.description$
+        $if(service.details)$\newline \begin{itemize}
+          $for(service.details)$\scriptsize \item $service.details$
           $endfor$ \end{itemize}
           $endif$ & $service.price$\\$endfor$ \noalign{\vskip 2mm} \hline
   $if(VAT)$
-    @ & @ \multicolumn{1}{r}{Subtotal:}                & :={sum(c1:[0,-1])} \\ \hhline{~~-}
-    @ & @ \multicolumn{1}{r}{VAT $VAT$\%:}               & $VAT$/100*[0,-1] \\ \hhline{~~-}
+    @ & @ \multicolumn{1}{r}{\localSubtotal:}                & :={sum(c1:[0,-1])} \\ \hhline{~~-}
+    @ & @ \multicolumn{1}{r}{\localVAT $VAT$\%:}               & $VAT$/100*[0,-1] \\ \hhline{~~-}
   $endif$
-  @ & @ \multicolumn{1}{r}{\textbf{Total:}}   & \textbf{:={$if(VAT)$[0,-1]+[0,-2]$else$sum(c1:[0,-1])$endif$}} \\ \hhline{~~-}
+  @ & @ \multicolumn{1}{r}{\textbf{\localTotal:}}   & \textbf{:={$if(VAT)$[0,-1]+[0,-2]tag(totalsum)$else$sum(c1:[0,-1])tag(totalsum)$endif$}} \\ \hhline{~~-}
 \end{spreadtab}
 
 
@@ -148,5 +166,9 @@ $closingnote$
 \medskip
 
 $author$
+
+$for(signature)$
+ \includegraphics[width=3cm]{$signature$}
+$endfor$
 
 \end{document}

--- a/template.tex
+++ b/template.tex
@@ -61,6 +61,9 @@ $endif$
 \setlist[itemize]{leftmargin=0.5cm} % Reduce list left indent
 \setlength{\tabcolsep}{9pt} % Larger gutter between columns
 
+% allow including of signatures
+\usepackage{graphicx}
+
 % MACROS
 \newcommand{\total}{\STtag{totalsum}}
 % MACROS:Locale


### PR DESCRIPTION
Localization had to be done by editing the latex template and can now be done clearer and more efficiently via (optional) configuration keys

Note:
**`lang`** was renamed to **`language`** as pandoc yelled at me how I dared to use lang with a value different from IETF style which isodate is not okay with..
**`commasep`** has become part of the localization object 


 I really like this tool, it came very handy recently 