### PR TITLE
Check pandoc version before setting engine flag

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,11 @@
 TEX = pandoc
+PANDOC_VERSION = $(shell pandoc -v | head -n 1 | sed -e 's/pandoc //g' | awk -F. '{print $$1}')
 src = template.tex details.yml
-FLAGS = --pdf-engine=xelatex
+ifeq ($(PANDOC_VERSION),1)
+	FLAGS = --latex-engine=xelatex
+else
+	FLAGS = --pdf-engine=xelatex
+endif
 
 output.pdf : $(src)
 	$(TEX) $(filter-out $<,$^ ) -o $@ --template=$< $(FLAGS)


### PR DESCRIPTION
Pandoc uses `--pdf-engine` since 2.0, older versions use `--latex-engine`.
Now we check the pandoc version before setting the engine flag.

This addresses issue #11 