### PR TITLE
Fix "english" to "en-GB" as reqd. by Pandoc

### DIFF
--- a/details.yml
+++ b/details.yml
@@ -39,7 +39,7 @@ closingnote: |
 # Invoice settings
 currency: EUR
 # commasep: true
-lang: english
+lang: en-GB
 
 # Typography and layout
 seriffont: Hoefler Text


### PR DESCRIPTION
This fixes https://github.com/mrzool/invoice-boilerplate/issues/16 as discovered and documented by @thestr4ng3r in https://github.com/mrzool/invoice-boilerplate/issues/16#issuecomment-729651565