### PR TITLE
Switch from polyglossia to babel

### DIFF
--- a/details.yml
+++ b/details.yml
@@ -39,7 +39,7 @@ closingnote: |
 # Invoice settings
 currency: EUR
 # commasep: true
-lang: en-GB
+lang: english
 
 # Typography and layout
 seriffont: Hoefler Text

--- a/template.tex
+++ b/template.tex
@@ -65,8 +65,7 @@ $endif$
 % LANGUAGE
 %--------------------------------
 $if(lang)$
-\usepackage{polyglossia}
-\setmainlanguage{$polyglossia-lang.name$}
+\usepackage[$lang$]{babel}
 $endif$
 
 % PDF SETUP


### PR DESCRIPTION
This change follows https://github.com/jgm/pandoc/pull/7562 (apparently `babel` is now recommended by `pandoc` over `polyglossia`)
Fixes #24